### PR TITLE
Fix: Keyboard not dismissing on onboarding

### DIFF
--- a/Siply/OnboardingView.swift
+++ b/Siply/OnboardingView.swift
@@ -153,6 +153,9 @@ struct OnboardingView: View {
     }
 
     private func handleNext() {
+        // Dismiss keyboard before moving to next page
+        isNameFieldFocused = false
+
         withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
             if currentPage < totalPages - 1 {
                 currentPage += 1


### PR DESCRIPTION
## Problem
When entering your name in the onboarding flow and tapping "Next", the keyboard remained open and covered the UI on the next screens (Goal Setup, Reminder Setup).

## Solution
- Dismiss keyboard automatically when navigating away from name input screen
- Set `isNameFieldFocused = false` in `handleNext()` function before page transition

## Changes
- `OnboardingView.swift:156-157` - Added keyboard dismissal logic

## Testing
1. Start onboarding flow
2. Enter name on screen 4 (Name Input)
3. Tap "Next" button
4. ✅ Keyboard should close immediately
5. ✅ Next screen (Goal Setup) should be fully visible

## Before
- Keyboard stays open on Goal Setup screen
- UI elements hidden behind keyboard

## After  
- Keyboard dismisses cleanly when tapping Next
- Full UI visible on all screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)